### PR TITLE
Ajuste Criação de Empresas - Administrador.

### DIFF
--- a/src/main/java/br/com/ottimizza/application/controllers/OrganizationController.java
+++ b/src/main/java/br/com/ottimizza/application/controllers/OrganizationController.java
@@ -62,10 +62,12 @@ public class OrganizationController {
     }
 
     @PostMapping
-    public HttpEntity<?> create(@RequestBody OrganizationDTO organizationDTO,  
+    public HttpEntity<?> create(@RequestBody OrganizationDTO organizationDTO,
+                                @RequestParam(name = "ignoreAccountingFilter", required=false, defaultValue = "false")
+                                boolean ignoreAccountingFilter,
                                 Principal principal) throws Exception {
         return ResponseEntity.ok(new GenericResponse<OrganizationDTO>(
-            organizationService.create(organizationDTO, principal)));
+            organizationService.create(organizationDTO, ignoreAccountingFilter, principal)));
     }
 
     @PatchMapping("/{id}")

--- a/src/main/java/br/com/ottimizza/application/services/OrganizationService.java
+++ b/src/main/java/br/com/ottimizza/application/services/OrganizationService.java
@@ -97,21 +97,35 @@ public class OrganizationService {
         return results.map(OrganizationDTO::fromEntity);
     }
 
-    public OrganizationDTO create(OrganizationDTO organizationDTO, Principal principal)
+    public OrganizationDTO create(OrganizationDTO organizationDTO, boolean ignoreAccountingFilter, Principal principal)
             throws IllegalArgumentException, OrganizationAlreadyRegisteredException, Exception {
         User authenticated = userService.findByUsername(principal.getName());
         Organization organization = organizationDTO.toEntity();
 
-        if (organization.getType() == Organization.Type.CLIENT) {
-            organization.setOrganization(authenticated.getOrganization());
-        }
-        
-        if (authenticated.getType().equals(User.Type.ACCOUNTANT)) {
-            organization.setType(Organization.Type.CLIENT);
+        // Filtros de Usuários da Ottimizza (Administradores).
+        if (authenticated.getType().equals(User.Type.ADMINISTRATOR)) {
+            if (organizationDTO.getOrganizationId() == null && !ignoreAccountingFilter) {
+                organization.setOrganization(authenticated.getOrganization());
+            } else {
+                Organization accounting = new Organization();
+                accounting.setId(organizationDTO.getOrganizationId());
+                
+                organization.setOrganization(accounting);
+            }
+        } else {
+            if (organization.getType() == Organization.Type.CLIENT) {
+                organization.setOrganization(authenticated.getOrganization());
+            }
             
-        } else if (authenticated.getType().equals(User.Type.CUSTOMER)) {
-            throw new AccessDeniedException("Você não tem permissão para criar empresas!");
+            if (authenticated.getType().equals(User.Type.ACCOUNTANT)) {
+                organization.setType(Organization.Type.CLIENT);
+                
+            } else if (authenticated.getType().equals(User.Type.CUSTOMER)) {
+                throw new AccessDeniedException("Você não tem permissão para criar empresas!");
+            }
         }
+
+        
         checkRequiredFields(organization);
         checkIfOrganizationIsNotParentOfItself(organization);
         checkIfOrganizationIsNotAlreadyRegistered(organization);

--- a/src/main/java/br/com/ottimizza/application/services/OrganizationService.java
+++ b/src/main/java/br/com/ottimizza/application/services/OrganizationService.java
@@ -104,7 +104,7 @@ public class OrganizationService {
 
         // Filtros de Usuários da Ottimizza (Administradores).
         if (authenticated.getType().equals(User.Type.ADMINISTRATOR)) {
-            if (organizationDTO.getOrganizationId() == null && !ignoreAccountingFilter) {
+            if (organizationDTO.getOrganizationId() == null || !ignoreAccountingFilter) {
                 organization.setOrganization(authenticated.getOrganization());
             } else {
                 Organization accounting = new Organization();

--- a/src/test/java/br/com/ottimizza/application/services/OrganizationServiceTest.java
+++ b/src/test/java/br/com/ottimizza/application/services/OrganizationServiceTest.java
@@ -38,7 +38,7 @@ class OrganizationServiceTest {
             .name("Accounting Firm Co")
             .cnpj("00000000000101")
             .type(Organization.Type.ACCOUNTING).build();
-        OrganizationDTO created = organizationService.create(organizationDTO, principal);
+        OrganizationDTO created = organizationService.create(organizationDTO, false, principal);
         Assertions.assertNotNull(created);
         Assertions.assertNotNull(created.getId());
 	}
@@ -51,7 +51,7 @@ class OrganizationServiceTest {
             .cnpj("00000000000101")
             .type(Organization.Type.ACCOUNTING).build();
         Assertions.assertThrows(OrganizationAlreadyRegisteredException.class, () -> {
-            organizationService.create(organizationDTO, principal);
+            organizationService.create(organizationDTO, false, principal);
         });
 	}
 
@@ -62,7 +62,7 @@ class OrganizationServiceTest {
             .name("Accounting Firm Co")
             .cnpj("00000000000101").build();
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            organizationService.create(organizationDTO, principal);
+            organizationService.create(organizationDTO, false, principal);
         });
 	}
 
@@ -74,7 +74,7 @@ class OrganizationServiceTest {
             .cnpj("00000000000101")
             .type(99).build();
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            organizationService.create(organizationDTO, principal);
+            organizationService.create(organizationDTO, false, principal);
         });
 	}
 
@@ -85,7 +85,7 @@ class OrganizationServiceTest {
             .cnpj("00000000000101")
             .type(Organization.Type.ACCOUNTING).build();
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            organizationService.create(organizationDTO, principal);
+            organizationService.create(organizationDTO, false, principal);
         });
 	}
 
@@ -97,7 +97,7 @@ class OrganizationServiceTest {
             .cnpj("00000000000101")
             .type(Organization.Type.ACCOUNTING).build();
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            organizationService.create(organizationDTO, principal);
+            organizationService.create(organizationDTO, false, principal);
         });
 	}
 
@@ -108,7 +108,7 @@ class OrganizationServiceTest {
             .name("Example Company Ltd")
             .type(Organization.Type.ACCOUNTING).build();
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            organizationService.create(organizationDTO, principal);
+            organizationService.create(organizationDTO, false, principal);
         });
 	}
 
@@ -120,7 +120,7 @@ class OrganizationServiceTest {
             .cnpj("")
             .type(Organization.Type.ACCOUNTING).build();
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            organizationService.create(organizationDTO, principal);
+            organizationService.create(organizationDTO, false, principal);
         });
 	}
 
@@ -134,7 +134,7 @@ class OrganizationServiceTest {
             .type(Organization.Type.CLIENT).build();
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            organizationService.create(organizationDTO, principal);
+            organizationService.create(organizationDTO, false, principal);
         });
 	}
 


### PR DESCRIPTION
Adicionado atributo 'ignoreAccountingFilter' na requisição de criação de empresas.

Quando usuário for do tipo ADM, ignoreAccountingFilter for TRUE e organizationId for diferente de null, seta o id da contabilidade manualmente.